### PR TITLE
Updates for beta 2 platform.

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -17,7 +17,7 @@ version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
-	maven(url = "../lib/conclave-cloud-sdk-java-1.0.0-beta1/repo")
+	maven(url = "../lib/conclave-cloud-sdk-java-1.0.0-beta2/repo")
 	mavenCentral()
 }
 
@@ -31,7 +31,7 @@ dependencies {
 	implementation("info.picocli:picocli:4.6.1")
 
 	// Conclave Cloud
-	implementation("com.r3.conclave.cloud:conclave-cloud-sdk:1.0.0-beta1")
+	implementation("com.r3.conclave.cloud:conclave-cloud-sdk:1.0.0-beta2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/cli/src/main/kotlin/com/r3/conclavepass/FunctionsBackend.kt
+++ b/cli/src/main/kotlin/com/r3/conclavepass/FunctionsBackend.kt
@@ -7,11 +7,9 @@ import com.r3.conclave.common.SHA256Hash
 import com.r3.conclavecloud.Conclave
 import com.r3.conclavecloud.client.ConclaveClientConfig
 
-// Ensure these ID's match the values in your project.
-//  ccl platform tenant
-//  ccl projects list
-val tenantID = "[TODO: Replace with your Tenant ID]"
-val projectID = "[TODO: Replace with your Project ID]"
+// You need to generate an API key within your project and paste it here.
+//  ccl apikeys create
+val apiKey = "[TODO: Replace with an API key generated for your project]"
 
 // Ensure these hashes match the actual hashes of the uploaded code
 //  ccl functions list
@@ -32,7 +30,7 @@ class FunctionsBackend {
     private val mapper = jacksonObjectMapper()
 
     // Create the Conclave SDK instance
-    val conclave = Conclave.create(ConclaveClientConfig(tenantID, projectID, Conclave.PRODUCTION_API_URL))
+    val conclave = Conclave.create(ConclaveClientConfig(apiKey, Conclave.PRODUCTION_API_URL))
 
     fun getPasswords(): List<PasswordEntry> {
         val entries = mutableListOf<PasswordEntry>()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "~10.2.0",
     "@angular/platform-browser-dynamic": "~10.2.0",
     "@angular/router": "~10.2.0",
-    "conclave-cloud-sdk": "file:../lib/conclave-cloud-sdk-js-1.0.0-beta1",
+    "conclave-cloud-sdk": "file:../lib/conclave-cloud-sdk-js-1.0.0-beta2",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/frontend/src/app/ccl.service.ts
+++ b/frontend/src/app/ccl.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@angular/core';
 import { Conclave } from 'conclave-cloud-sdk';
 import { AuthService } from './auth.service';
 
-const tenantID = "[TODO: Replace with your Tenant ID]";
-const projectID = "[TODO: Replace with your Project ID]";
+const apiKey = "[TODO: Replace with an API key generated for your project]";
 const queryHash = "AD7635832EDC36AF1ED9C38E0FD57F5E056AD0215F86A7E5BACCB330A32D8E40";
 const addEntryHash = "DD442ADA05F2469E3AA6F10A33A3914FF13C7318AFC9713D5BDCA8C3AD8C26DF";
 const getHash = "3CFC30B748EF865D518C4C03109375AB91EC355F53ED5166C09197BF7540D9BD";
@@ -27,8 +26,8 @@ export class CclService {
     private auth: AuthService
   ) { 
     this.conclave = Conclave.create({
-      tenantID: tenantID,
-      projectID: projectID
+      apiKey: apiKey,
+      apiURL: Conclave.PRODUCTION_API_URL
     });
 
   }


### PR DESCRIPTION
Changed to use beta 2 dependencies and to use an API key instead of Tenant ID/Project ID.